### PR TITLE
Step 6: add Claude skills (.claude/skills/)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,6 +27,10 @@ Both documents are shared across all implementations. Never modify them for plat
 
 ## Critical Rules
 
+### Git Workflow
+- **NEVER merge pull requests** — merging PRs is always a manual action by the developer
+- Never push to remote without explicit user instruction
+
 ### patches.json
 - **NEVER** edit `patches.json` manually — the dbpatch CLI owns this file
 - Use `dbpatch addpatch -n <name>` to create patches; it generates the ID and updates dependencies

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,6 +34,11 @@ Both documents are shared across all implementations. Never modify them for plat
 ### patches.json
 - **NEVER** edit `patches.json` manually — the dbpatch CLI owns this file
 - Use `dbpatch addpatch -n <name>` to create patches; it generates the ID and updates dependencies
+- **Narrow exception — rename only:** After renaming a patch folder to match `SCENARIO.md`
+  timestamps, you may manually update:
+  - The renamed patch's `id` field to match the new folder name
+  - Any `dependsOn` entries in *other* patches that reference the old `id`
+  - Nothing else — do not add, remove, or reorder patches by hand
 
 ### ScriptOverrides
 - **ODBC MySQL**: Copy `ScriptOverrides/` from an existing ODBC MySQL implementation

--- a/.claude/skills/create-example/SKILL.md
+++ b/.claude/skills/create-example/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: create-example
+description: Create a new scenario from scratch — guides Phases 1-3 (concept, SCHEMA_DESIGN.md, SCENARIO.md), scaffolds the folder structure, stubs test-data/data-manifest.json, and updates README.md.
+disable-model-invocation: true
+argument-hint: "[scenario-name]"
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Edit
+  - Write
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - EnterPlanMode
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+---
+
+# Create a New Scenario
+
+You are creating a new database scenario from scratch. If a scenario name was provided it is: **$ARGUMENTS**
+
+This skill covers **Phases 1–3**: concept → `SCHEMA_DESIGN.md` → `SCENARIO.md`. Phase 4 (first implementation) is handled by the `new-implementation` skill.
+
+If no scenario name was provided, start at Phase 1 and gather it from the user.
+
+---
+
+## Phase 1: Concept
+
+Gather the following from the user (ask if not already provided):
+
+1. **Domain** — What kind of organization or system is this? (e.g., retail, HR, healthcare, logistics)
+2. **Company or org name** — Give it a specific, fictional name to ground the narrative
+3. **Problem to solve** — What business problem does the database address?
+4. **Rough entities** — What are the main things the database tracks? (5–15 entities is a good range)
+5. **Scale** — Small (~8 layers, ~10 tables), medium (~12 layers, ~15 tables), or large (~15+ layers, ~20+ tables)?
+6. **Scenario folder name** — `PascalCase-DB` format, e.g., `Employee-DB`, `ECommerce-DB`, `Hospital-DB`
+
+Read `DEVELOPERS.md` to see the available cast of characters. These developers will appear in the scenario narrative.
+
+Present a concept summary to the user for approval before proceeding to Phase 2.
+
+---
+
+## Phase 2: Schema Design → `SCHEMA_DESIGN.md`
+
+Use `EnterPlanMode` to design the full layer structure before writing anything.
+
+**Layer design principles:**
+- Layer 0: Core tables with no dependencies (the "root" entities)
+- Layer 1+: Build on previous layers; each layer adds a coherent capability
+- Parallel layers (1a, 1b, 1c): Independent features that can be built in any order
+- Dependencies converge: a later layer that requires all of 1a/1b/1c lists all three as dependencies
+- Add intentional technical debt: one or two design mistakes that get corrected later (adds realism)
+- Aim for 1–3 tables per layer (avoid monolithic layers)
+
+**Platform-agnostic spec conventions:**
+- Column types use logical descriptions, not platform SQL:
+  - Use `identifier, auto-generated` not `INT AUTO_INCREMENT`
+  - Use `text, up to 100 characters` not `VARCHAR(100)`
+  - Use `boolean` not `TINYINT(1)` or `BIT`
+  - Use `datetime` not `DATETIME` or `DATETIME2`
+  - Use `decimal(10,2)` format for decimals
+- Mark required/optional explicitly: `required` / `optional, nullable`
+- Note default values where they exist
+- Note indexes on non-PK columns that will be needed
+
+**Status markers:**
+- `📋 Planned` — not yet implemented in any implementation
+- `✅ Complete` — implemented in at least one implementation
+- `⚠️ Blocked` — depends on something not yet done
+
+Read `docs/SCHEMA_AND_SCENARIO_GUIDE.md` for the full authoring spec before writing.
+
+**File location:** `<Scenario-DB>/SCHEMA_DESIGN.md` (at the scenario root, not inside any implementation folder)
+
+After writing `SCHEMA_DESIGN.md`, present it to the user for review before proceeding to Phase 3.
+
+---
+
+## Phase 3: Scenario Writing → `SCENARIO.md`
+
+Write the team narrative that gives the schema history and context.
+
+**Narrative elements:**
+- Pick 3–5 developers from `DEVELOPERS.md` who will "build" this database
+- Assign roles: who leads, who implements, who reviews
+- Set a realistic start date (past, not future) and a timeline spanning weeks or months
+- Each layer has a date/time it was implemented — these become patch folder timestamps
+- Include realistic details: design discussions, mistakes made, corrections, reviews
+- Write developer conversations (brief exchanges, not essays)
+- Make technical debt explicit: show the decision that caused it, and the later correction
+
+**Timestamp rules:**
+- Work happens during business hours (9am–6pm)
+- Developers work in bursts with gaps (not one layer per hour all day)
+- Multiple layers on one day is fine; a few weeks between phases is realistic
+- Timestamps must be consistent with the dependency order in `SCHEMA_DESIGN.md`
+
+Read `docs/SCHEMA_AND_SCENARIO_GUIDE.md` for the full scenario authoring spec and `DEVELOPERS.md` for developer profiles.
+
+**File location:** `<Scenario-DB>/SCENARIO.md` (same folder as `SCHEMA_DESIGN.md`)
+
+---
+
+## Phase 4: Scaffold the Folder Structure
+
+After the user approves `SCENARIO.md`, create the initial folder structure:
+
+```bash
+mkdir -p <Scenario-DB>/test-data
+```
+
+**Stub `test-data/data-manifest.json`:**
+
+```json
+{
+  "loadOrder": [],
+  "tables": {}
+}
+```
+
+Leave `loadOrder` and `tables` empty — they will be populated when test data CSVs are created (Step 6b of the project plan).
+
+**Do NOT create any implementation folder yet** — that is the `new-implementation` skill's job.
+
+---
+
+## Phase 5: Update `README.md`
+
+Add the new scenario to the scenario index table in the repo root `README.md`:
+
+- Add a row to the "Scenarios" table with: scenario name, description, layer count (from `SCHEMA_DESIGN.md`), status (`In progress`), implementations (`None yet`)
+- Do not rewrite other sections of `README.md`
+
+---
+
+## Phase 6: Summary
+
+Report to the user:
+- Scenario name and folder created
+- Layer count and structure summary
+- Developers assigned from `DEVELOPERS.md`
+- Timeline span
+- Files created: `SCHEMA_DESIGN.md`, `SCENARIO.md`, `test-data/data-manifest.json`
+- Next step: use `/new-implementation` to scaffold the first implementation
+
+---
+
+## Important Reminders
+
+- **Both canonical docs are shared** across all implementations — never add platform-specific content to them
+- **Get user approval** at the end of Phase 1 (concept) and Phase 2 (schema) before continuing
+- **Timestamps in SCENARIO.md** drive patch folder names — make them realistic and consistent with the dependency order
+- **Read `DEVELOPERS.md`** before assigning characters — use the defined profiles, don't invent new developers

--- a/.claude/skills/dbpatch-v2-implement-layer/SKILL.md
+++ b/.claude/skills/dbpatch-v2-implement-layer/SKILL.md
@@ -99,7 +99,10 @@ This creates the patch folder with the current timestamp and updates `patches.js
    ```
    Keep the random 4-digit suffix — only change the timestamp portion.
 
-2. **Update `patches.json`** — change the `id` field to match the renamed folder. Also verify `dependsOn` references are correct. This is the only time editing `patches.json` is permitted — only to update the ID after a rename.
+2. **Update `patches.json`** — this is the only permitted manual edit, scoped strictly to the rename:
+   - Change this patch's `id` to match the renamed folder name
+   - Update any `dependsOn` entries in *other* patches that reference the old `id`
+   - Do not add, remove, reorder, or change any other fields — the CLI owns everything else
 
 ---
 

--- a/.claude/skills/dbpatch-v2-implement-layer/SKILL.md
+++ b/.claude/skills/dbpatch-v2-implement-layer/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: dbpatch-v2-implement-layer
+description: Implement one layer from SCHEMA_DESIGN.md into a DBPatch v2 project. Reads the layer spec and SCENARIO.md timestamp, creates and renames the patch, writes platform SQL, builds against Docker, validates, and marks the layer complete in SCHEMA_DESIGN.md.
+disable-model-invocation: true
+argument-hint: "<layer-name> [path/to/implementation]"
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(docker *)
+  - Bash(docker compose *)
+  - Bash(dbpatch *)
+  - Bash(pwsh *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Bash(mv *)
+  - Edit
+  - Write
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - EnterPlanMode
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+---
+
+# Implement a DBPatch v2 Layer
+
+You are implementing one layer from a scenario's `SCHEMA_DESIGN.md` into a DBPatch v2 implementation. The layer name or number is: **$ARGUMENTS**
+
+If no layer is specified, ask the user which layer to implement and in which implementation directory before proceeding.
+
+---
+
+## Phase 0: Locate Files
+
+Identify the working paths. If `$ARGUMENTS` includes a path, use it. Otherwise, infer from the current directory:
+
+1. **Scenario root** — contains `SCHEMA_DESIGN.md` and `SCENARIO.md`. Walk up from the current directory until found.
+2. **Implementation root** — the current directory if it contains `patches.json`, or ask the user.
+
+```bash
+# Confirm you are in the right implementation directory
+ls patches.json
+```
+
+If `patches.json` is not found, ask the user for the implementation path before continuing.
+
+---
+
+## Phase 1: Read the Specification
+
+Read both canonical documents:
+
+1. **`SCHEMA_DESIGN.md`** — Find the target layer. Note:
+   - All tables to create and their columns, types, constraints
+   - ALTER TABLE changes to existing tables
+   - Foreign keys and indexes to add
+   - Seed data to insert (reference/lookup tables)
+   - Layer dependencies (which patches this layer must `dependsOn`)
+   - Current layer status (must be `📋` — do not re-implement a `✅` layer)
+
+2. **`SCENARIO.md`** — Find the date/time this layer was implemented. You will use this for the patch ID timestamp.
+
+If the layer status is already `✅`, stop and tell the user — do not re-implement.
+
+---
+
+## Phase 2: Plan
+
+Use `EnterPlanMode` before writing any SQL or creating any files:
+
+- Identify each SQL file needed (tables, FKs, indexes, seed data)
+- Determine the correct file numbering order (circular references require two-phase pattern — see below)
+- Confirm which existing patches this layer `dependsOn` (must match `SCHEMA_DESIGN.md` dependency graph)
+- Confirm the timestamp from `SCENARIO.md`
+
+Present the plan. Do not proceed to Phase 3 without user approval or unless the plan is unambiguous.
+
+---
+
+## Phase 3: Create and Rename the Patch
+
+```bash
+# From the implementation root
+dbpatch addpatch -n <layer-description>
+```
+
+This creates the patch folder with the current timestamp and updates `patches.json`. Then:
+
+1. **Rename the folder** to use the SCENARIO.md timestamp:
+   ```bash
+   # Example: old name was 202503051423-7812-add-employee-roles
+   # SCENARIO.md says this layer was implemented 2024-01-29 at 09:15
+   mv Patches/202503051423-7812-add-employee-roles Patches/202401290915-7812-add-employee-roles
+   ```
+   Keep the random 4-digit suffix — only change the timestamp portion.
+
+2. **Update `patches.json`** — change the `id` field to match the renamed folder. Also verify `dependsOn` references are correct. This is the only time editing `patches.json` is permitted — only to update the ID after a rename.
+
+---
+
+## Phase 4: Write the SQL Files
+
+Add numbered `.sql` files to the new patch folder. Files execute alphabetically — use numeric prefixes to control order.
+
+**Translate SCHEMA_DESIGN.md logical types to platform SQL:**
+
+| Logical Type | MySQL |
+|---|---|
+| `identifier, auto-generated` | `INT AUTO_INCREMENT PRIMARY KEY` |
+| `text, up to X characters` | `VARCHAR(X)` |
+| `text, unlimited` | `TEXT` |
+| `boolean` | `TINYINT(1)` |
+| `date` | `DATE` |
+| `datetime` | `DATETIME` |
+| `decimal(P,S)` | `DECIMAL(P,S)` |
+| `integer` | `INT` |
+| Required field | `NOT NULL` |
+| Optional field | `NULL` |
+
+**Full type mapping for other platforms:** see `docs/IMPLEMENTATION_GUIDE.md`.
+
+**Circular reference pattern** (e.g., Employee <-> Department):
+```
+1_employee.sql        -- CREATE TABLE Employee (DepartmentId INT NULL -- no FK yet)
+2_department.sql      -- CREATE TABLE Department (DepartmentHeadId INT NULL -- no FK yet)
+3_department_fk.sql   -- ALTER TABLE Department ADD CONSTRAINT FK_DeptHead FOREIGN KEY ...
+4_employee_fk.sql     -- ALTER TABLE Employee ADD CONSTRAINT FK_Dept FOREIGN KEY ...
+```
+
+**Add indexes** on all FK columns (MySQL does not auto-index FKs).
+
+**Seed data** (reference/lookup tables): add as the last numbered file in the patch.
+
+**Never copy SQL from another implementation.** Always generate fresh from `SCHEMA_DESIGN.md`.
+
+---
+
+## Phase 5: Build and Validate
+
+```bash
+# Start the database container (leave it running after — do not run docker compose down)
+docker compose up -d
+
+# Apply all patches
+dbpatch build
+```
+
+If `dbpatch build` fails:
+- Read the error message — it identifies the failing SQL file
+- Fix the SQL and re-run `dbpatch build`
+- Do not retry the same build without a change
+
+**Validation queries** — after a successful build, run queries to confirm the layer is correct:
+
+```bash
+# Confirm tables were created (MySQL example)
+docker exec <container-name> mysql -u root -p<password> <database> -e "SHOW TABLES;"
+
+# Confirm columns and types
+docker exec <container-name> mysql -u root -p<password> <database> -e "DESCRIBE <table>;"
+
+# Confirm foreign keys
+docker exec <container-name> mysql -u root -p<password> <database> \
+  -e "SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA='<database>' AND REFERENCED_TABLE_NAME IS NOT NULL;"
+
+# Confirm patch was recorded
+docker exec <container-name> mysql -u root -p<password> <database> -e "SELECT * FROM InstalledPatches;"
+```
+
+Surface any errors or unexpected results to the user before continuing.
+
+Leave the container running. Never run `docker compose down` during implementation.
+
+---
+
+## Phase 6: Add CRUD Stored Procedures (if tables were created)
+
+For each new table in this layer, add stored procedures to `Code/`. These run on every `dbpatch build` (idempotent — drop and recreate each time).
+
+Naming: `<Operation><TableName>.<suffix>.sql`
+
+| Operation | File suffix | Pattern |
+|---|---|---|
+| Create | `.sproc.sql` | `DROP PROCEDURE IF EXISTS Create<Table>; DELIMITER $$ CREATE PROCEDURE Create<Table>(params) BEGIN INSERT ...; END $$ DELIMITER ;` |
+| Read | `.sproc.sql` | SELECT by primary key |
+| Update | `.sproc.sql` | UPDATE by primary key |
+| Delete | `.sproc.sql` | DELETE by primary key |
+
+All Code files must use `DROP ... IF EXISTS` before `CREATE`.
+
+---
+
+## Phase 7: Update SCHEMA_DESIGN.md
+
+Change the layer's status from `📋` to `✅` in the layer summary table.
+
+---
+
+## Phase 8: Summary
+
+Report to the user:
+- Layer implemented: name, patch ID, files created
+- Validation results (tables, row counts if seed data was inserted)
+- Any deviations from the spec and why
+- Next layer to implement (from the dependency graph in SCHEMA_DESIGN.md)
+
+---
+
+## Important Reminders
+
+- **NEVER edit `patches.json` directly** except to update the ID after a rename
+- **NEVER copy SQL from another implementation** — generate fresh from `SCHEMA_DESIGN.md`
+- **NEVER copy ScriptOverrides from a different database platform**
+- **Ask before proceeding** if the spec is ambiguous or dependencies are unclear
+- **Leave Docker running** — do not tear down the database between layers

--- a/.claude/skills/new-implementation/SKILL.md
+++ b/.claude/skills/new-implementation/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: new-implementation
+description: Scaffold a new tool+platform implementation of an existing scenario — creates the folder structure, docker-compose.yml, ScriptOverrides, test-connection.ps1, load-test-data.ps1, and then implements each layer using the dbpatch-v2-implement-layer skill.
+disable-model-invocation: true
+argument-hint: "<scenario-path> <tool/platform> (e.g., Employee-DB dbpatchv2/odbc-mysql)"
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(docker *)
+  - Bash(docker compose *)
+  - Bash(dbpatch *)
+  - Bash(pwsh *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Bash(cp *)
+  - Edit
+  - Write
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - EnterPlanMode
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+---
+
+# Scaffold a New Implementation
+
+You are scaffolding a new tool+platform implementation for an existing scenario. The arguments are: **$ARGUMENTS**
+
+Expected format: `<scenario-path> <tool/platform>`
+Example: `Employee-DB dbpatchv2/odbc-mysql`
+
+If arguments are missing or ambiguous, ask the user for:
+1. **Scenario path** — e.g., `Employee-DB` (must have `SCHEMA_DESIGN.md` and `SCENARIO.md`)
+2. **Tool** — e.g., `dbpatchv2`, `dbpatchv3`, `rawsql`
+3. **Platform** — e.g., `odbc-mysql`, `odbc-sqlserver`, `native-postgresql`
+4. **Database name** — what to name the database (e.g., `EmployeeDB`)
+5. **Database credentials** — root password for docker-compose and test-connection.ps1
+
+This skill handles DBPatch v2 implementations. For v3 or raw SQL, the skill will note what needs adaptation.
+
+---
+
+## Phase 0: Read the Scenario
+
+Before creating anything, read:
+
+1. `<scenario>/SCHEMA_DESIGN.md` — understand all layers, tables, and dependency graph
+2. `<scenario>/SCENARIO.md` — understand the timeline (used by layer implementation)
+3. If an existing implementation of the same platform exists, read its folder structure for reference (e.g., if adding `odbc-mysql2`, read `odbc-mysql/`)
+
+Identify:
+- Total number of layers to implement
+- Whether a reference implementation already exists for this platform (affects ScriptOverrides)
+- The database platform (MySQL, SQL Server, PostgreSQL)
+
+---
+
+## Phase 1: Create the Folder Structure
+
+```bash
+mkdir -p <scenario>/dbpatchv2/<platform>/Patches
+mkdir -p <scenario>/dbpatchv2/<platform>/Code
+mkdir -p <scenario>/dbpatchv2/<platform>/ScriptOverrides
+```
+
+---
+
+## Phase 2: Initialize DBPatch
+
+```bash
+cd <scenario>/dbpatchv2/<platform>
+dbpatch init --dbtype odbc
+```
+
+This creates `patches.json`. Verify it was created with the correct `DatabaseType`.
+
+---
+
+## Phase 3: ScriptOverrides
+
+Determine which ScriptOverrides to use:
+
+```
+Is this ODBC (--dbtype odbc)?
+|
++-- YES: Does an existing implementation for the SAME database platform already exist in this repo?
+|   |
+|   +-- YES (e.g., second odbc-mysql): COPY ScriptOverrides from that implementation.
+|   |
+|   +-- NO (first time with this platform via ODBC): CREATE new ScriptOverrides.
+|
++-- NO (native driver): No ScriptOverrides needed.
+```
+
+**Copy from existing ODBC MySQL implementation:**
+```bash
+cp <scenario>/dbpatchv2/odbc-mysql/ScriptOverrides/* ScriptOverrides/
+```
+
+**Create new for a new ODBC platform** — three files required:
+
+`ScriptOverrides/InitPatchTable.sql` — creates the tracking table using target platform DDL
+`ScriptOverrides/AddInstalledPatch.sql` — inserts a completed patch record
+`ScriptOverrides/GetInstalledPatches.sql` — returns all installed patch names
+
+See `docs/IMPLEMENTATION_GUIDE.md` for the MySQL reference implementation of these files.
+Never copy ScriptOverrides from a different database platform.
+
+---
+
+## Phase 4: docker-compose.yml
+
+Create `docker-compose.yml` to spin up the database. Use the existing `odbc-mysql/docker-compose.yml` as a reference if one exists.
+
+MySQL example:
+```yaml
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: <scenario-lower>-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: yourpassword
+      MYSQL_DATABASE: <DatabaseName>
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./init-scripts:/docker-entrypoint-initdb.d
+```
+
+Add `init-scripts/01-init.sql` if initial setup SQL is needed (e.g., character set, timezone).
+
+---
+
+## Phase 5: patches.local.json
+
+Create a **template** that the developer fills in locally (this file is gitignored):
+
+```json
+{
+  "ConnectionString": "Driver={MySQL ODBC 8.0 Driver};Server=localhost;Port=3306;Database=<DatabaseName>;Uid=root;Pwd=yourpassword;"
+}
+```
+
+Add `patches.local.json` to the implementation's `.gitignore` if not already present.
+
+---
+
+## Phase 6: test-connection.ps1
+
+Create a PowerShell script that verifies the database is reachable before running `dbpatch build`.
+
+Use the existing `odbc-mysql/test-connection.ps1` as a reference if one exists. If not, write a script that:
+- Reads the connection string from `patches.local.json`
+- Attempts a simple query (`SELECT 1`)
+- Reports success or failure with a clear message
+
+---
+
+## Phase 7: load-test-data.ps1 (stub)
+
+Create a stub `load-test-data.ps1` that will load CSVs from `../../test-data/`:
+
+```powershell
+# load-test-data.ps1
+# Loads demo test data from ../../test-data/ into the database.
+# Reads ../../test-data/data-manifest.json for load order and column type hints.
+#
+# TODO: Implement after test-data/ CSVs and data-manifest.json are created (Step 6b).
+
+Write-Host "Test data loader not yet implemented for this implementation."
+Write-Host "See: Employee-DB/test-data/data-manifest.json for the data manifest."
+```
+
+Mark it as a stub — do not implement until `test-data/` CSVs exist.
+
+---
+
+## Phase 8: .gitignore
+
+Create or update `.gitignore` in the implementation root:
+
+```
+patches.local.json
+*.log
+```
+
+---
+
+## Phase 9: README.md
+
+Create a brief `README.md` for this implementation:
+
+```markdown
+# <Scenario> — DBPatch v2 / ODBC MySQL
+
+Implementation of <Scenario> using DBPatch v2 with the ODBC plugin targeting MySQL 8.0.
+
+## Requirements
+
+- Docker Desktop
+- DBPatch v2 CLI (`C:\dbpatch-v2\dbpatch.exe`)
+- MySQL ODBC 8.0 Driver
+
+## How to run
+
+1. `docker compose up -d`
+2. Copy `patches.local.json.example` to `patches.local.json` and set your connection string
+3. `dbpatch build`
+
+## Layers implemented
+
+| Layer | Status |
+|---|---|
+| (populate as layers are implemented) |
+```
+
+---
+
+## Phase 10: Implement Layers
+
+For each layer in `SCHEMA_DESIGN.md` (in dependency order), invoke the `dbpatch-v2-implement-layer` skill:
+
+```
+/dbpatch-v2-implement-layer <layer-name>
+```
+
+Work through layers one at a time. Do not start a new layer until the previous one builds successfully.
+
+After all layers are implemented, update the README.md layers table with final status.
+
+---
+
+## Phase 11: Summary
+
+Report to the user:
+- Implementation path created
+- Layers implemented (count, names)
+- Docker container status
+- Any deviations or issues encountered
+- Next step: create test data (`test-data/` CSVs + manifest) and implement `load-test-data.ps1`
+
+---
+
+## Important Reminders
+
+- **NEVER copy ScriptOverrides from a different database platform**
+- **NEVER edit `patches.json` manually** (except to rename a patch ID after a folder rename)
+- **NEVER copy SQL from another implementation** — generate fresh from `SCHEMA_DESIGN.md`
+- **Ask the user** before starting layer implementation if there are ambiguities in the spec
+- **Leave Docker running** between layers — do not tear down the database mid-implementation

--- a/.claude/skills/new-implementation/SKILL.md
+++ b/.claude/skills/new-implementation/SKILL.md
@@ -137,9 +137,9 @@ Add `init-scripts/01-init.sql` if initial setup SQL is needed (e.g., character s
 
 ---
 
-## Phase 5: patches.local.json
+## Phase 5: Connection string template
 
-Create a **template** that the developer fills in locally (this file is gitignored):
+Create and **commit** `dbpatch.local.example.json` as a template developers can copy:
 
 ```json
 {
@@ -147,7 +147,17 @@ Create a **template** that the developer fills in locally (this file is gitignor
 }
 ```
 
-Add `patches.local.json` to the implementation's `.gitignore` if not already present.
+Add `patches.local.json` (the filled-in local copy, not the example) to `.gitignore`:
+
+```
+patches.local.json
+```
+
+Developers copy the example and fill in their own credentials:
+```bash
+cp dbpatch.local.example.json patches.local.json
+# then edit patches.local.json with real values
+```
 
 ---
 
@@ -210,7 +220,7 @@ Implementation of <Scenario> using DBPatch v2 with the ODBC plugin targeting MyS
 ## How to run
 
 1. `docker compose up -d`
-2. Copy `patches.local.json.example` to `patches.local.json` and set your connection string
+2. Copy `dbpatch.local.example.json` to `patches.local.json` and set your connection string
 3. `dbpatch build`
 
 ## Layers implemented

--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: review-feedback
+description: Triage and address PR code review comments — assess validity, plan fixes, implement, validate with Docker + dbpatch, and report decisions to the user.
+disable-model-invocation: true
+argument-hint: "[pr-number] (auto-detects from current branch if omitted)"
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(docker *)
+  - Bash(docker compose *)
+  - Bash(dbpatch *)
+  - Bash(pwsh *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Edit
+  - Write
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+---
+
+# Address PR Code Review Feedback
+
+Determine the PR number:
+1. If `$ARGUMENTS` contains a number, use that
+2. Otherwise, auto-detect from the current branch:
+   ```bash
+   gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
+   ```
+3. If no PR is found, ask the user for the PR number
+
+---
+
+## Phase 1: Gather Comments
+
+```bash
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+gh api "repos/$REPO/pulls/<PR_NUMBER>/comments" --jq '.[] | {id, path, line, body, user: .user.login}'
+gh api "repos/$REPO/pulls/<PR_NUMBER>/reviews" --jq '.[] | {user: .user.login, state, body}'
+```
+
+---
+
+## Phase 2: Triage — Assess Each Comment
+
+For each comment, read the relevant code and assess:
+
+1. **Is it valid?** Does it identify a real bug, quality issue, or improvement?
+2. **Priority?** High (correctness/bug), Medium (quality), Low (style/nice-to-have), Trivial (cosmetic)
+3. **Fix it?** Valid comments may still be out of scope, speculative, or conflict with project conventions.
+
+**Present a summary table to the user before implementing anything:**
+
+| # | Comment (summary) | Valid? | Priority | Action |
+|---|-------------------|--------|----------|--------|
+| 1 | ...               | Yes    | High     | Fix — real bug |
+| 2 | ...               | Yes    | Low      | Skip — cosmetic |
+| 3 | ...               | No     | —        | Skip — misunderstands design |
+
+For each skip recommendation, explain why. **Ask the user which comments to address before proceeding.** Do not implement anything without user approval on the triage.
+
+---
+
+## Phase 3: Plan Fixes
+
+For approved comments:
+- Group related comments that can be fixed together
+- Identify which files need changes
+- Check if fixes could affect patch execution order or `dependsOn` graph
+- Note if any fix requires a new patch (schema change) vs. editing existing files
+
+---
+
+## Phase 4: Implement Fixes
+
+For each approved fix:
+1. Make the code change
+2. If the fix corrects SQL in a patch, verify the patch ID and `dependsOn` are still correct
+3. If the fix adds a new patch, use `dbpatch addpatch -n <name>` (never hand-edit `patches.json`)
+
+Follow all project conventions (see `docs/IMPLEMENTATION_GUIDE.md` and `.claude/CLAUDE.md`).
+
+---
+
+## Phase 5: Validate
+
+For any SQL or schema fixes, validate against a running database:
+
+```bash
+# Start Docker if not running
+docker compose up -d
+
+# Apply all patches
+dbpatch build
+```
+
+If `dbpatch build` fails, fix and re-run. Do not retry without a change.
+
+Run validation queries to confirm the fix is correct (see `docs/IMPLEMENTATION_GUIDE.md` Phase 5).
+
+---
+
+## Phase 6: Report to User
+
+Summarize what was done:
+
+- **Fixed:** List each comment addressed and what changed
+- **Skipped (approved):** Comments agreed to skip, with rationale
+- **Skipped (user override):** Comments the user decided not to fix
+- **New issues found:** Any problems discovered during fixes not in the original review
+
+---
+
+## Phase 7: Commit
+
+```bash
+git add <specific-files>
+git commit -m "fix: address PR review feedback (#<PR_NUMBER>)"
+```
+
+**Do NOT push** unless the user explicitly asks.
+**Do NOT merge the PR** — PR merging is always a manual action by the developer.
+**Do NOT add Co-Authored-By or Claude attribution.**
+
+---
+
+## Important Reminders
+
+- **The user decides** what gets fixed — always present triage before implementing
+- **Explain your reasoning** for skip recommendations
+- **Don't over-fix** — address what was raised, don't refactor nearby code
+- **Never merge PRs** — the developer does that manually
+- **If a comment requires a design change**, flag it — it may warrant a separate issue

--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -39,11 +39,22 @@ Determine the PR number:
 
 ## Phase 1: Gather Comments
 
+Store the repo name and PR number in shell variables first so every subsequent command uses them consistently:
+
 ```bash
 REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
-gh api "repos/$REPO/pulls/<PR_NUMBER>/comments" --jq '.[] | {id, path, line, body, user: .user.login}'
-gh api "repos/$REPO/pulls/<PR_NUMBER>/reviews" --jq '.[] | {user: .user.login, state, body}'
+PR_NUMBER=<PR_NUMBER>
+
+# Fetch all inline review comments (includes the comment id needed for replies)
+gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments" \
+  --jq '.[] | {id, path, line, body, user: .user.login}'
+
+# Fetch top-level review summaries
+gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+  --jq '.[] | {id, user: .user.login, state, body}'
 ```
+
+Record each comment's `id` alongside the file, line, and body. You will need these IDs in Phase 8 to post replies to the correct threads.
 
 ---
 
@@ -127,6 +138,31 @@ git commit -m "fix: address PR review feedback (#<PR_NUMBER>)"
 **Do NOT push** unless the user explicitly asks.
 **Do NOT merge the PR** — PR merging is always a manual action by the developer.
 **Do NOT add Co-Authored-By or Claude attribution.**
+
+---
+
+## Phase 8: Reply to Review Threads (if user asks to push or explicitly requests replies)
+
+After the commit is pushed, post a reply on each review comment thread using the comment `id` recorded in Phase 1. Use the exact `id` for each comment — do not guess or match by file/line alone.
+
+```bash
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+COMMIT="$(git rev-parse --short HEAD)"
+
+# For a comment that was fixed:
+gh api "repos/$REPO/pulls/comments/<COMMENT_ID>/replies" \
+  -f body="Fixed in $COMMIT: <one-sentence explanation of what changed>"
+
+# For a comment that was intentionally not fixed:
+gh api "repos/$REPO/pulls/comments/<COMMENT_ID>/replies" \
+  -f body="Won't fix: <explanation of why this was declined or is out of scope>"
+```
+
+**Critical rules for replies:**
+- Match each reply to the specific `id` from Phase 1 — never approximate by file or line number
+- Every addressed comment gets a reply; every skipped comment gets a "Won't fix" reply
+- Do NOT resolve threads — leave that for the developer to do after reviewing the replies
+- Do NOT reply to top-level review summaries (the `reviews` endpoint) — only to inline comments
 
 ---
 

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: work-issue
+description: Work on a GitHub issue end-to-end — reads the issue, creates a feature branch, plans the implementation, implements, validates with Docker + dbpatch, self-reviews, and commits.
+disable-model-invocation: true
+argument-hint: "<issue-number>"
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(docker *)
+  - Bash(docker compose *)
+  - Bash(dbpatch *)
+  - Bash(pwsh *)
+  - Bash(mkdir *)
+  - Bash(ls *)
+  - Bash(cp *)
+  - Bash(mv *)
+  - Edit
+  - Write
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - EnterPlanMode
+  - EnterWorktree
+  - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+---
+
+# Work on GitHub Issue
+
+You are implementing a GitHub issue end-to-end. The issue number is: **$ARGUMENTS**
+
+If no issue number is provided, ask the user for one before proceeding.
+
+---
+
+## Phase 0: Setup — Branch
+
+1. **Read the issue:**
+   ```bash
+   gh issue view $ARGUMENTS
+   ```
+
+2. **Create a feature branch** from `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b feature/<descriptive-branch-name>
+   ```
+   Branch name must follow `feature/<kebab-case-description>` format.
+
+3. **Assign and label the issue:**
+   ```bash
+   gh issue edit $ARGUMENTS --add-assignee @me
+   gh issue edit $ARGUMENTS --add-label in-progress
+   ```
+
+4. **Link the branch to the issue:**
+   ```bash
+   gh issue develop $ARGUMENTS --branch feature/<descriptive-branch-name>
+   ```
+
+---
+
+## Phase 1: Plan
+
+Use `EnterPlanMode` to design the implementation before writing any files:
+
+- Read the relevant canonical docs (`SCHEMA_DESIGN.md`, `SCENARIO.md`, `docs/`) to understand the context
+- Identify all files that need to change
+- Determine if this is schema work (use `dbpatch-v2-implement-layer` skill), scaffolding (use `new-implementation` skill), or another type of change
+- Consider edge cases and doc updates
+- Present the plan for user approval before proceeding
+
+Do NOT skip planning. The plan catches design mistakes before any files are touched.
+
+---
+
+## Phase 2: Implement
+
+Follow the appropriate workflow based on issue type:
+
+**Schema / layer work:** Use the `dbpatch-v2-implement-layer` skill for each layer.
+
+**Scaffolding a new implementation:** Use the `new-implementation` skill.
+
+**New scenario:** Use the `create-example` skill.
+
+**Documentation or tooling changes:**
+- Follow existing patterns in the codebase
+- Keep changes focused — do not refactor unrelated files
+- Update only files directly related to the issue
+
+All work must follow the conventions in `docs/IMPLEMENTATION_GUIDE.md` and `.claude/CLAUDE.md`.
+
+---
+
+## Phase 3: Validate
+
+For schema changes, validate against a running database:
+
+```bash
+# Start Docker if not already running
+docker compose up -d
+
+# Apply all patches
+dbpatch build
+
+# Run validation queries (tables, columns, constraints, seed data)
+# See docs/IMPLEMENTATION_GUIDE.md — Phase 5 of the per-layer workflow
+```
+
+For documentation or tooling changes, review the output manually.
+
+If `dbpatch build` fails, fix the SQL and re-run. Do not retry without a change.
+
+---
+
+## Phase 4: Self Code Review
+
+Before declaring done:
+
+- [ ] SQL generated fresh from `SCHEMA_DESIGN.md` — not copied from another implementation
+- [ ] `patches.json` not hand-edited (only patch ID updated after folder rename)
+- [ ] ScriptOverrides not copied from a different database platform
+- [ ] Layer status updated in `SCHEMA_DESIGN.md` (📋 → ✅) if layers were implemented
+- [ ] Timestamps in patch folder names match `SCENARIO.md` timeline
+- [ ] `dependsOn` in `patches.json` matches the dependency graph in `SCHEMA_DESIGN.md`
+- [ ] `patches.local.json` not committed (gitignored)
+- [ ] README.md or docs updated if the change adds or changes something user-visible
+- [ ] No platform-specific content added to `SCHEMA_DESIGN.md` or `SCENARIO.md`
+
+---
+
+## Phase 5: Commit
+
+Create a well-structured commit:
+
+```bash
+git add <specific-files>
+git commit -m "feat: descriptive message (closes #$ARGUMENTS)"
+```
+
+**Do NOT push** unless the user explicitly asks.
+**Do NOT merge the PR** — PR merging is always a manual action by the developer.
+**Do NOT add Co-Authored-By or Claude attribution.**
+
+---
+
+## Important Reminders
+
+- **Ask before proceeding** if requirements are ambiguous
+- **Never merge PRs** — the developer does that manually
+- **Read canonical docs first** — `SCHEMA_DESIGN.md` is the source of truth for all SQL
+- **Another reviewer will check this work** — quality matters

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -57,9 +57,13 @@ If no issue number is provided, ask the user for one before proceeding.
    gh issue edit $ARGUMENTS --add-label in-progress
    ```
 
-4. **Link the branch to the issue:**
+4. **Link the branch to the issue** (requires `gh` CLI v2.28+):
    ```bash
    gh issue develop $ARGUMENTS --branch feature/<descriptive-branch-name>
+   ```
+   If this command is unavailable (older `gh`), post a comment instead:
+   ```bash
+   gh issue comment $ARGUMENTS --body "Working on this in branch \`feature/<descriptive-branch-name>\`."
    ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds 5 Claude Code skills to `.claude/skills/` for AI-assisted development workflows
- Adds a Git Workflow critical rule to `.claude/CLAUDE.md`: agents must never merge PRs

## Skills added

| Skill | Purpose |
|---|---|
| `dbpatch-v2-implement-layer` | Implement one layer end-to-end: read spec → create patch → rename to SCENARIO.md timestamp → write SQL → build → validate → mark done |
| `create-example` | New scenario phases 1–3: concept → `SCHEMA_DESIGN.md` → `SCENARIO.md` → scaffold |
| `new-implementation` | Scaffold a new tool+platform implementation and implement all layers |
| `work-issue` | GitHub issue end-to-end: branch → plan → implement → validate → commit |
| `review-feedback` | PR review triage: assess comments → user approval → fix → validate → commit |

`work-issue` and `review-feedback` are adapted from the `Export-SqlServerSchema` repo's skills — same phase structure, swapped to Docker + dbpatch + validation queries.

## Notes

- Skills are auto-discovered by Claude Code from `.claude/skills/<name>/SKILL.md`
- All skills include the "never merge PRs" reminder
- `dbpatch-v2-implement-layer` is the core skill; `new-implementation` invokes it per layer